### PR TITLE
chore(storybook): fix wrong import Preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Preview } from '@storybook/react';
+import type { Preview } from '@storybook/react';
 import { GrapesProvider } from '../src/components/GrapesProvider';
 import { LOCALES } from '../src/components/GrapesProvider/exampleLocales';
 


### PR DESCRIPTION
### Context

Update import from `@storybook/react` to fix the following issue:

```
Uncaught SyntaxError: The requested module 'http://localhost:6006/node_modules/.cache/storybook/1c3385a5d25e538d10b518b310c74d3ca2690b6aaffeadccd74da79736171f86/sb-vite/deps/@storybook_react.js?v=023e8c8e' doesn't provide an export named: 'Preview'
```