### PR TITLE
ci(Chromatic): add option exitOnceUploaded

### DIFF
--- a/.github/workflows/build-test-and-lint.yml
+++ b/.github/workflows/build-test-and-lint.yml
@@ -85,6 +85,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT }}
           skip: '@(beta|alpha|0.x|dependabot/**)'
           autoAcceptChanges: 'master'
+          exitOnceUploaded: true
           buildScriptName: build-storybook-test
 
   release:


### PR DESCRIPTION
### Context

Add option `exitOnceUploaded` to Chromatic job as recommanded by the CI:
> Your project is linked to GitHub so Chromatic will report results there. This means you can add the option `with: exitOnceUploaded: true` to your workflow to skip waiting for build results.


Documentation: https://www.chromatic.com/docs/configure/#exitonceuploaded