### PR TITLE
fix(Label): use body/m instead of title/m for form field labels

### DIFF
--- a/src/components/Label/Label.module.scss
+++ b/src/components/Label/Label.module.scss
@@ -16,7 +16,7 @@
 }
 
 .labelContainer > label {
-  font: var(--title-m);
+  font: var(--body-m);
   color: var(--color-content-primary);
 }
 


### PR DESCRIPTION
### Context

PR following this message:
https://spendesk.slack.com/archives/C01LY6SM0QZ/p1751472262469369
<img width="708" alt="image" src="https://github.com/user-attachments/assets/1ce764c0-ae39-4bd7-b8f4-bb011aad1e79" />

Notion page:
https://www.notion.so/spendesk/Tech-Fix-label-text-styles-224e916ba8b180d6ae60d2397abe5234