### PR TITLE
chore(banner): replace button props with actions node

### DIFF
--- a/src/components/Banner/Banner.module.scss
+++ b/src/components/Banner/Banner.module.scss
@@ -30,3 +30,8 @@
   color: var(--color-content-secondary-bg-secondary);
   margin: 0;
 }
+
+.actions {
+  display: flex;
+  gap: var(--unit-8);
+}

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Banner } from './';
+import { Button } from '../Button';
 
 describe('Banner component', () => {
   it('displays a title and a description', () => {
@@ -10,9 +11,14 @@ describe('Banner component', () => {
     render(
       <Banner
         title="Hello world"
-        onClick={vi.fn()}
-        actionText="Say Hello"
         illustration={<img src="" alt="nothing" />}
+        actions={
+          <Button
+            variant="secondaryNeutral"
+            onClick={vi.fn()}
+            text="Say Hello"
+          />
+        }
       >
         {randomDescription}
       </Banner>,
@@ -29,21 +35,37 @@ describe('Banner component', () => {
     ).toBeVisible();
   });
 
-  it('calls onClick when user click on the button', async () => {
-    const handleClick = vi.fn();
+  it('calls onClick when user click on actions', async () => {
+    const handleClick1 = vi.fn();
+    const handleClick2 = vi.fn();
     render(
       <Banner
         title="Hello world"
-        onClick={handleClick}
-        actionText="Say Hello"
         illustration={<img src="" alt="nothing" />}
+        actions={
+          <>
+            <Button
+              variant="secondaryNeutral"
+              onClick={handleClick1}
+              text="Say Hello"
+            />
+            <Button
+              variant="tertiaryNeutral"
+              onClick={handleClick2}
+              text="Say Goodbye"
+            />
+          </>
+        }
       >
         Sunt quia cum aliquid vitae.
       </Banner>,
     );
 
-    expect(handleClick).not.toHaveBeenCalled();
+    expect(handleClick1).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole('button', { name: 'Say Hello' }));
-    expect(handleClick).toHaveBeenCalled();
+    expect(handleClick1).toHaveBeenCalled();
+    expect(handleClick2).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Say Goodbye' }));
+    expect(handleClick2).toHaveBeenCalled();
   });
 });

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,9 +1,8 @@
-import React, { type MouseEventHandler, type ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import { classNames } from '../../utils';
 
 import styles from './Banner.module.scss';
 import { useId } from '../../hooks/useId';
-import { Button, type ButtonVariant } from '../Button';
 
 export type BannerVariant = 'brand' | 'neutral';
 
@@ -18,14 +17,6 @@ export type BannerProps = {
    */
   title: ReactNode;
   /**
-   * Content of the button
-   */
-  actionText: string;
-  /**
-   * Handler that is called when the button is clicked
-   */
-  onClick: MouseEventHandler<HTMLElement>;
-  /**
    * Illustration on the left side of the Banner.
    * Illustration will be centered vertically with margin on both left and right
    */
@@ -39,10 +30,9 @@ export type BannerProps = {
    */
   className?: string;
   /**
-   * The visual style of the button
-   * @default secondaryNeutral
+   * Action buttons to be displayed in the Banner
    */
-  buttonVariant?: ButtonVariant;
+  actions: ReactNode;
 };
 
 /**
@@ -52,11 +42,9 @@ export const Banner = ({
   variant = 'brand',
   title,
   children,
-  actionText,
   className,
   illustration,
-  onClick,
-  buttonVariant = 'secondaryNeutral',
+  actions,
 }: BannerProps) => {
   const titleId = useId();
   const descriptionId = useId();
@@ -76,7 +64,7 @@ export const Banner = ({
         <p className={styles.description} id={descriptionId}>
           {children}
         </p>
-        <Button variant={buttonVariant} text={actionText} onClick={onClick} />
+        <div className={styles.actions}>{actions}</div>
       </div>
     </aside>
   );

--- a/src/components/Banner/stories/Banner.stories.tsx
+++ b/src/components/Banner/stories/Banner.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import illustration from './illustration.webp';
 
 import { Banner } from '../Banner';
+import { Button } from '../../Button';
 import { SnapshotContainer } from '../../../test-utils/SnapshotsContainer';
 
 const meta: Meta<typeof Banner> = {
@@ -23,7 +24,13 @@ export const Brand: Story = {
   ],
   args: {
     title: 'Track your budgets',
-    actionText: 'Set up sub-budgets',
+    actions: (
+      <Button
+        variant="secondaryNeutral"
+        onClick={() => {}}
+        text="Set up sub-budgets"
+      />
+    ),
     illustration: <img src={illustration} alt="" height="100px" />,
     children:
       'You can now track sub-budgets based on expense categories. It will help you track your budgets with more granularity and precision.',
@@ -35,7 +42,13 @@ export const Neutral: Story = {
   args: {
     variant: 'neutral',
     title: 'Track your budget with Spendesk',
-    actionText: 'See my budget',
+    actions: (
+      <Button
+        variant="secondaryNeutral"
+        onClick={() => {}}
+        text="See my budget"
+      />
+    ),
     illustration: <img src={illustration} alt="" height="100px" />,
     children:
       'You can now experience accurate and efficient expense tracking. Try it out!',
@@ -47,11 +60,33 @@ export const WithPrimaryButton: Story = {
   args: {
     variant: 'neutral',
     title: 'Track your budget with Spendesk',
-    actionText: 'See my budget',
+    actions: (
+      <Button variant="primaryBrand" onClick={() => {}} text="See my budget" />
+    ),
     illustration: <img src={illustration} alt="" height="100px" />,
     children:
       'You can now experience accurate and efficient expense tracking. Try it out!',
-    buttonVariant: 'primaryBrand',
+  },
+};
+
+export const WithTwoButtons: Story = {
+  ...Brand,
+  args: {
+    variant: 'neutral',
+    title: 'Track your budget with Spendesk',
+    actions: (
+      <>
+        <Button onClick={() => {}} text="See my budget" />
+        <Button
+          variant="tertiaryNeutral"
+          onClick={() => {}}
+          text="Click here for more info"
+        />
+      </>
+    ),
+    illustration: <img src={illustration} alt="" height="100px" />,
+    children:
+      'You can now experience accurate and efficient expense tracking. Try it out!',
   },
 };
 
@@ -60,7 +95,13 @@ export const WithoutIllustration: Story = {
   args: {
     variant: 'neutral',
     title: 'Track your budget with Spendesk',
-    actionText: 'See my budget',
+    actions: (
+      <Button
+        variant="secondaryNeutral"
+        onClick={() => {}}
+        text="See my budget"
+      />
+    ),
     children:
       'You can now experience accurate and efficient expense tracking. Try it out!',
   },


### PR DESCRIPTION
### Context

Add a tertiary button near the original button in `Banner`.

Solution proposed: accept an `actions` expecting buttons to be displayed instead of multiplying button props 

[Figma](https://www.figma.com/design/SpkppjQ9HwZa4RWiFrUrIk/%F0%9F%8D%87%F0%9F%92%BB-Compo.---Web?node-id=7-5726&t=AoPjzQZR2EY6uM2G-4)
[Notion](https://www.notion.so/spendesk/Tech-add-tertiary-button-to-the-banner-222e916ba8b1804686c2e418ae088e97?source=copy_link)

![image](https://github.com/user-attachments/assets/8654f062-bbfc-4816-9c2c-6fa6f006081a)
