### PR TITLE
fix(Dropdown): Add overflow hidden to fix cropped border in corners when content has a background

### DIFF
--- a/src/theme/placeholders/_dropdown.scss
+++ b/src/theme/placeholders/_dropdown.scss
@@ -5,4 +5,5 @@
   border-radius: var(--border-radius-12);
   z-index: var(--z-index-dropdown);
   box-sizing: border-box;
+  overflow: hidden;
 }


### PR DESCRIPTION
Issue 👇 
<img width="561" height="648" alt="image" src="https://github.com/user-attachments/assets/0b3b8d4f-f6d4-4af4-a314-a2a101e535fb" />


overflow:hidden fixes it
