### PR TITLE
Revert "fix(Dropdown): Add overflow hidden to fix cropped border in corners when content has a background"

### DIFF
--- a/src/theme/placeholders/_dropdown.scss
+++ b/src/theme/placeholders/_dropdown.scss
@@ -5,5 +5,4 @@
   border-radius: var(--border-radius-12);
   z-index: var(--z-index-dropdown);
   box-sizing: border-box;
-  overflow: hidden;
 }


### PR DESCRIPTION
## Context

This new overflow is creating many problems in the Spendesk application. The dropdown can no longer extend beyond the popover, preventing users from selecting options.

<img width="843" height="321" alt="image" src="https://github.com/user-attachments/assets/ee4f1347-bdd1-4978-99d7-4588caad80dd" />
