### PR TITLE
feat(RadioBox): Add highlightIconVariant prop

### DIFF
--- a/src/components/RadioBox/RadioBox.tsx
+++ b/src/components/RadioBox/RadioBox.tsx
@@ -7,6 +7,7 @@ import { useRadioCheckState } from '../RadioGroup/useRadioCheckState';
 
 import styles from './RadioBox.module.scss';
 import { HighlightIcon } from '../HighlightIcon';
+import type { HighlightIconVariant } from '../HighlightIcon';
 
 export type RadioBoxProps<K> = {
   /**
@@ -25,6 +26,11 @@ export type RadioBoxProps<K> = {
    * The icon to display in the button
    */
   iconName?: IconName;
+  /**
+   * The variant of the icon background.
+   * @default purple
+   */
+  iconVariant?: HighlightIconVariant;
   /**
    * Whether the RadioBox should be disabled.
    * @default false
@@ -48,6 +54,7 @@ export const RadioBox = <K extends string | boolean>({
   className,
   isDisabled = false,
   iconName,
+  iconVariant = 'purple',
   value,
   label,
   description,
@@ -74,7 +81,12 @@ export const RadioBox = <K extends string | boolean>({
         aria-describedby={description ? descriptionId : undefined}
       />
       {iconName ? (
-        <HighlightIcon name={iconName} size={32} variant="purple" aria-hidden />
+        <HighlightIcon
+          name={iconName}
+          size={32}
+          variant={iconVariant}
+          aria-hidden
+        />
       ) : null}
       <div>
         <div className={styles.label} id={labelId}>


### PR DESCRIPTION
### Context

The background of RadioBox icons can't currently be changed. I added a new prop to allow for the selection of any highlight icon variant.

<img width="1440" height="874" alt="image" src="https://github.com/user-attachments/assets/ffb70075-b472-4d84-a04c-afa0c1ab473a" />
