### PR TITLE
fix(amount-input): use newValue

### DIFF
--- a/src/components/AmountInput/stories/AmountInput.stories.tsx
+++ b/src/components/AmountInput/stories/AmountInput.stories.tsx
@@ -42,8 +42,8 @@ export const Default: Story = {
           <AmountInput
             {...args}
             value={selectedValue}
-            onChange={(event) => {
-              setSelectedValue(event.target.valueAsNumber);
+            onChange={(_, newValue) => {
+              setSelectedValue(newValue);
             }}
           />
         </FormField>
@@ -89,8 +89,8 @@ export const InADisabledFieldset: Story = {
             <AmountInput
               {...args}
               value={selectedValue}
-              onChange={(event) => {
-                setSelectedValue(event.target.valueAsNumber);
+              onChange={(_, newValue) => {
+                setSelectedValue(newValue);
               }}
             />
           </FormField>
@@ -120,8 +120,8 @@ export const EditableCurrency: Story = {
         <FormField label="Amount input">
           <AmountInput
             {...args}
-            onChange={(event) => {
-              setAmount(event.target.valueAsNumber);
+            onChange={(_, newValue) => {
+              setAmount(newValue);
             }}
             value={amount}
             currency={currency}


### PR DESCRIPTION
### Context

There was an issue when typing negative values with default parameters (ie with `hasNegativeValueAllowed` being `false`):

<img width="1428" height="623" alt="Screenshot 2025-08-21 at 11 40 35" src="https://github.com/user-attachments/assets/8323ceae-7c86-4394-833d-df98a524e3ca" />

The value received in the `onChange` was `-1` but the input was displaying `1`. This is because we were not using `newValue`, the second parameter of `onChange` function. We will need to update all usages of `AmountInput` that aren't using the `newValue`, starting from the documentation.
