### PR TITLE
feat(Marvin): kill robot icon and replace with sparkle

### DIFF
--- a/src/components/AmountInput/stories/AmountInput.stories.tsx
+++ b/src/components/AmountInput/stories/AmountInput.stories.tsx
@@ -67,7 +67,7 @@ export const WithLeftAddon: Story = {
   args: {
     leftAddon: (
       <div style={{ marginLeft: '8px', marginTop: '4px' }}>
-        <Icon name="robot" aria-label="Robot" />
+        <Icon name="sparkle" aria-label="sparkle" />
       </div>
     ),
   },

--- a/src/components/Label/stories/Label.stories.tsx
+++ b/src/components/Label/stories/Label.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Label } from '../Label';
 import { Icon } from '../../Icon';
+import { colors } from '../../..';
 
 const meta: Meta<typeof Label> = {
   title: 'Form/Label',
@@ -26,11 +27,11 @@ export const Hint: Story = {
   },
 };
 
-export const MarvinHint: Story = {
+export const AISparkleHint: Story = {
   args: {
     fit: 'parent',
     label: 'My label',
-    hint: <Icon name="robot" />,
+    hint: <Icon name="sparkle" color={colors.contentBrandDefault} />,
   },
 };
 


### PR DESCRIPTION
### Context

The robot icon is outdated. We replaced it with the sparkle icon.

<img width="719" height="670" alt="image" src="https://github.com/user-attachments/assets/cc80f0ae-d8eb-4cb1-87cb-e1afc3a2678e" />
