### PR TITLE
fix(design-token): add new entrypoint for design-token

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "require": "./dist/index.js"
     },
     "./tailwind": "./dist/tailwind-grapes.css",
-    "./style": "./dist/style.css"
+    "./style": "./dist/index.css",
+    "./token": "./dist/token.css"
   },
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -49,10 +49,9 @@ export default defineConfig({
     target: 'esnext',
     emptyOutDir: false,
     sourcemap: false,
+    cssCodeSplit: true,
     lib: {
-      entry: 'src/index.ts',
-      fileName: 'index',
-      cssFileName: 'style',
+      entry: { index: 'src/index.ts', token: 'src/theme/css-variables.css' },
       formats: ['es', 'cjs'],
     },
     rollupOptions: {


### PR DESCRIPTION
### Context

Unexpected behavior of #134. Design tokens are not part of the CSS bundle anymore.

This PR resolves the issue by adding a new entry point for the design tokens.

This also allows projects that use only Tailwind to include just the design tokens from Grapes, rather than all the associated CSS.

<!-- Before submitting the PR, please make sure you do the following -->
<!-- Title your PR using a descriptive message that follows the angular conventions -->
<!-- If relevant, link your PR to an issue using keyword: `Closes:`, `Fixes:` -->
