### PR TITLE
feat(Tooltip): remove marginLeft in favor of paddingBoundary

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ export type TooltipProps = {
   content: ReactNode | ReactNode[];
   /**
    * Whether the trigger is a custom element
-   * @see {@link storybook.spendesk.design/index.html?path=/docs/feedback-tooltip--docs#triggeraschild-and-forwardref} for more information.
+   * @see https://grapes.spendesk.design/docs/components/tooltip#triggeraschild-and-forwardref
    * @default false
    */
   triggerAsChild?: boolean;
@@ -33,11 +33,6 @@ export type TooltipProps = {
    * @default false
    */
   isDisabled?: boolean;
-  /**
-   * The offset of the tooltip from its trigger on the x-axis.
-   * @default 0
-   */
-  xOffset?: number;
 } & TooltipOptions;
 
 /**
@@ -50,7 +45,6 @@ export function Tooltip({
   triggerAsChild = false,
   maxWidth = 232,
   isDisabled = false,
-  xOffset = 0,
   ...options
 }: TooltipProps) {
   const tooltip = useTooltip(options);
@@ -62,11 +56,7 @@ export function Tooltip({
   return (
     <TooltipContext.Provider value={tooltip}>
       <TooltipTrigger asChild={triggerAsChild}>{children}</TooltipTrigger>
-      <TooltipContent
-        maxWidth={maxWidth}
-        isDisabled={isDisabled}
-        marginLeft={`${xOffset}px`}
-      >
+      <TooltipContent maxWidth={maxWidth} isDisabled={isDisabled}>
         {content}
       </TooltipContent>
     </TooltipContext.Provider>

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -15,53 +15,40 @@ export const TooltipContent = /*@__PURE__*/ forwardRef<
   React.HTMLProps<HTMLDivElement> & {
     maxWidth: number;
     isDisabled: boolean;
-    marginLeft: string;
   }
->(
-  (
-    { style, children, maxWidth, isDisabled, marginLeft, ...props },
-    propRef,
-  ) => {
-    const {
-      floatingStyles,
-      isOpen,
-      refs,
-      arrowRef,
-      context,
-      getFloatingProps,
-    } = useTooltipContext();
-    const ref = useMergeRefs([refs.setFloating, propRef]);
+>(({ style, children, maxWidth, isDisabled, ...props }, propRef) => {
+  const { floatingStyles, isOpen, refs, arrowRef, context, getFloatingProps } =
+    useTooltipContext();
+  const ref = useMergeRefs([refs.setFloating, propRef]);
 
-    if (isDisabled || !isOpen) {
-      return null;
-    }
+  if (isDisabled || !isOpen) {
+    return null;
+  }
 
-    return (
-      <FloatingPortal>
-        <div
-          ref={ref}
-          style={{
-            ...floatingStyles,
-            ...style,
-            maxWidth,
-            marginLeft,
-          }}
-          {...getFloatingProps({
-            ...props,
-            className: styles.tooltipContent,
-          })}
-        >
-          {children}
-          <FloatingArrow
-            ref={arrowRef}
-            context={context}
-            tipRadius={1}
-            fill={colors.backgroundComplementaryDefault}
-            width={14}
-            height={6}
-          />
-        </div>
-      </FloatingPortal>
-    );
-  },
-);
+  return (
+    <FloatingPortal>
+      <div
+        ref={ref}
+        style={{
+          ...floatingStyles,
+          ...style,
+          maxWidth,
+        }}
+        {...getFloatingProps({
+          ...props,
+          className: styles.tooltipContent,
+        })}
+      >
+        {children}
+        <FloatingArrow
+          ref={arrowRef}
+          context={context}
+          tipRadius={1}
+          fill={colors.backgroundComplementaryDefault}
+          width={14}
+          height={6}
+        />
+      </div>
+    </FloatingPortal>
+  );
+});

--- a/src/components/Tooltip/TooltipContext.ts
+++ b/src/components/Tooltip/TooltipContext.ts
@@ -39,6 +39,11 @@ export type TooltipOptions = {
    * @default 10
    */
   offset?: number;
+  /**
+   * Padding around the viewport
+   * @default 8px
+   */
+  paddingBoundary?: number;
 };
 
 export const useTooltip = ({
@@ -47,6 +52,7 @@ export const useTooltip = ({
   isOpen: controlledOpen,
   onOpenChange: setControlledOpen,
   offset: tooltipOffset = 10,
+  paddingBoundary = 8,
 }: TooltipOptions = {}) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(isInitialOpen);
   const arrowRef = useRef(null);
@@ -61,8 +67,12 @@ export const useTooltip = ({
     whileElementsMounted: autoUpdate,
     middleware: [
       offset(tooltipOffset),
-      flip(),
-      shift(),
+      flip({
+        padding: paddingBoundary,
+      }),
+      shift({
+        padding: paddingBoundary,
+      }),
       arrow({
         element: arrowRef,
       }),

--- a/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -145,7 +145,7 @@ export const TriggerAsChild: Story = {
 
 export const XOffset: Story = {
   args: {
-    xOffset: -30,
+    paddingBoundary: 50,
   },
   render: (args) => (
     <Tooltip {...args}>


### PR DESCRIPTION
### Context

Replace the `marginLeft` prop on the Tooltip component with the built-in feature of `floating-`ui to add padding around the boundary (viewport).

By default, the padding around the boundary will be set to `8px` by Grapes. However, consumers will have the flexibility to adjust this value using the `paddingBoundary` prop.

Below is a screenshot of the story where the padding boundary is increased to 50px:
<img width="357" height="212" alt="image" src="https://github.com/user-attachments/assets/566be21d-64a7-474d-af0e-e7f3347eb093" />
