### PR TITLE
fix(avatar): 100% breaks sizing on constrained spacing

### DIFF
--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -31,8 +31,8 @@
 .content {
   display: block;
   overflow: hidden;
-  width: 100%;
-  height: 100%;
+  width: var(--_size);
+  height: var(--_size);
   object-fit: cover;
 }
 


### PR DESCRIPTION
### Context

on a component with width-constrained space the `width: 100%` of the in-anchor `span` will not take 100% of its parent's width but setting it to its parent's width manually does fix the issue without changing the existing behaviour.

__before this PR__

<img width="442" height="112" alt="image" src="https://github.com/user-attachments/assets/e3d33eae-edde-47c4-ac53-5ea8226a6f76" />

__after this PR__

<img width="442" height="112" alt="image" src="https://github.com/user-attachments/assets/c1ab9c07-5dd8-44dd-b94e-59d7fe78d865" />
