### PR TITLE
fix(Banner): Switch p & h1 to div & h2

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -58,12 +58,12 @@ export const Banner = ({
     >
       {illustration}
       <div className={styles.container}>
-        <h1 className={styles.title} id={titleId}>
+        <h2 className={styles.title} id={titleId}>
           {title}
-        </h1>
-        <p className={styles.description} id={descriptionId}>
+        </h2>
+        <div className={styles.description} id={descriptionId}>
           {children}
-        </p>
+        </div>
         <div className={styles.actions}>{actions}</div>
       </div>
     </aside>


### PR DESCRIPTION
### Context

This P.R update the banner tags 
- Fix a React warning when we nest div tags inside the banner 
<img width="928" height="1122" alt="image" src="https://github.com/user-attachments/assets/1781b9aa-39d0-4910-8105-899417ed75bd" />
- Fix the h1 header (should be reserved for the main page title afaik)